### PR TITLE
Fix subclasses bug and add support for frozensets

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import pyfuncol
 [1, 2, 3, 4].par_map(lambda x: x * 2).par_filter(lambda x: x > 4)
 # [6, 8]
 
-{1, 2, 3, 4}.par_map(lambda x: x * 2).par_filter(lambda x: x > 4)
+{1, 2, 3, 4}.par_map(lambda x: x * 2).par_filter_not(lambda x: x <= 4)
 # {6, 8}
 
 {"a": 1, "b": 2, "c": 3}.par_flat_map(lambda kv: {kv[0]: kv[1] ** 2})
@@ -65,6 +65,8 @@ For dictionaries, please refer to the [docs](https://pyfuncol.readthedocs.io/en/
 For sets and frozensets, please refer to the [docs](https://pyfuncol.readthedocs.io/en/latest/pyfuncol.html#module-pyfuncol.set).
 
 For more details, please have a look at the [API reference](https://pyfuncol.readthedocs.io/en/latest/modules.html).
+
+We support all subclasses with default constructors (`OrderedDict`, for example).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pyfuncol provides parallel operations (for now `par_map`, `par_flat_map`, `par_f
 # {"a": 1, "b": 4, "c": 9}
 ```
 
-pyfuncol provides operations leveraging memoization to improve performance (for now `pure_map`, `pure_flat_map`, `par_filter` and `par_filter_not`). These versions work only for **pure** functions (i.e., all calls to the same args return the same value) on hashable inputs:
+pyfuncol provides operations leveraging memoization to improve performance (for now `pure_map`, `pure_flat_map`, `pure_filter` and `pure_filter_not`). These versions work only for **pure** functions (i.e., all calls to the same args return the same value) on hashable inputs:
 
 ```python
 [1, 2, 3, 4].pure_map(lambda x: x * 2).pure_filter(lambda x: x > 4)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For lists, please refer to the [docs](https://pyfuncol.readthedocs.io/en/latest/
 
 For dictionaries, please refer to the [docs](https://pyfuncol.readthedocs.io/en/latest/pyfuncol.html#module-pyfuncol.dict).
 
-For sets, please refer to the [docs](https://pyfuncol.readthedocs.io/en/latest/pyfuncol.html#module-pyfuncol.set).
+For sets and frozensets, please refer to the [docs](https://pyfuncol.readthedocs.io/en/latest/pyfuncol.html#module-pyfuncol.set).
 
 For more details, please have a look at the [API reference](https://pyfuncol.readthedocs.io/en/latest/modules.html).
 

--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -34,10 +34,7 @@ pyfuncol provides parallel operations (for now `par_map`, `par_flat_map`, `par_f
 # {"a": 1, "b": 4, "c": 9}
 ```
 
-<<<<<<< HEAD
-We support all subclasses with default constructors (`OrderedDict`, for example).
-=======
-pyfuncol provides operations leveraging memoization to improve performance (for now `pure_map`, `pure_flat_map`, `par_filter` and `par_filter_not`). These versions work only for **pure** functions (i.e., all calls to the same args return the same value) on hashable inputs:
+pyfuncol provides operations leveraging memoization to improve performance (for now `pure_map`, `pure_flat_map`, `pure_filter` and `pure_filter_not`). These versions work only for **pure** functions (i.e., all calls to the same args return the same value) on hashable inputs:
 
 ```python
 [1, 2, 3, 4].pure_map(lambda x: x * 2).pure_filter(lambda x: x > 4)
@@ -49,4 +46,5 @@ pyfuncol provides operations leveraging memoization to improve performance (for 
 {"a": 1, "b": 2, "c": 3}.pure_flat_map(lambda kv: {kv[0]: kv[1] ** 2})
 # {"a": 1, "b": 4, "c": 9}
 ```
->>>>>>> main
+
+We support all subclasses with default constructors (`OrderedDict`, for example).

--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -33,3 +33,5 @@ pyfuncol also provides parallel operations (for now `par_map`, `par_flat_map`, `
 {"a": 1, "b": 2, "c": 3}.par_flat_map(lambda kv: {kv[0]: kv[1] ** 2})
 # {"a": 1, "b": 4, "c": 9}
 ```
+
+We support all subclasses with default constructors (`OrderedDict`, for example).

--- a/pyfuncol/dict.py
+++ b/pyfuncol/dict.py
@@ -1,5 +1,6 @@
 from forbiddenfruit import curse
 from typing import Callable, Dict, Optional, Tuple, TypeVar, List
+from copy import deepcopy # needed to preserve subclasses after transformation
 
 A = TypeVar("A")
 B = TypeVar("B")
@@ -41,7 +42,30 @@ def filter(self: Dict[A, B], p: Callable[[Tuple[A, B]], bool]) -> Dict[A, B]:
     Returns:
         The filtered dict.
     """
-    return {k: v for k, v in self.items() if p((k, v))}
+    res = deepcopy(self)
+    res.clear()
+    for k, v in self.items():
+        if p((k, v)):
+            res[k] = v
+    return res
+
+
+def filter_not(self: Dict[A, B], p: Callable[[Tuple[A, B]], bool]) -> Dict[A, B]:
+    """
+    Selects all elements of this iterable collection which do not satisfy a predicate.
+
+    Args:
+        p: The predicate to not satisfy.
+
+    Returns:
+        The filtered dict.
+    """
+    res = deepcopy(self)
+    res.clear()
+    for k, v in self.items():
+        if not p((k, v)):
+            res[k] = v
+    return res
 
 
 def flat_map(self: Dict[A, B], f: Callable[[Tuple[A, B]], Dict[C, D]]) -> Dict[C, D]:
@@ -54,7 +78,8 @@ def flat_map(self: Dict[A, B], f: Callable[[Tuple[A, B]], Dict[C, D]]) -> Dict[C
     Returns:
         The new dict.
     """
-    res = {}
+    res = deepcopy(self)
+    res.clear()
     for k, v in self.items():
         d = f((k, v))
         res.update(d)
@@ -91,7 +116,8 @@ def map(self: Dict[A, B], f: Callable[[Tuple[A, B]], Tuple[C, D]]) -> Dict[C, D]
     Returns:
         The new dict.
     """
-    res = {}
+    res = deepcopy(self)
+    res.clear()
     for k, v in self.items():
         k1, v1 = f((k, v))
         res[k1] = v1
@@ -217,19 +243,6 @@ def find(self: Dict[A, B], p: Callable[[Tuple[A, B]], bool]) -> Optional[Tuple[A
     return None
 
 
-def filter_not(self: Dict[A, B], p: Callable[[Tuple[A, B]], bool]) -> Dict[A, B]:
-    """
-    Selects all elements of this iterable collection which do not satisfy a predicate.
-
-    Args:
-        p: The predicate to satisfy.
-
-    Returns:
-        The filtered dict.
-    """
-    return {k: v for k, v in self.items() if not p((k, v))}
-
-
 def extend_dict():
     """
     Extends the dict built-in type with methods.
@@ -237,6 +250,7 @@ def extend_dict():
     curse(dict, "contains", contains)
     curse(dict, "size", size)
     curse(dict, "filter", filter)
+    curse(dict, "filter_not", filter_not)
     curse(dict, "flat_map", flat_map)
     curse(dict, "foreach", foreach)
     curse(dict, "is_empty", is_empty)
@@ -247,4 +261,3 @@ def extend_dict():
     curse(dict, "fold_right", fold_right)
     curse(dict, "forall", forall)
     curse(dict, "find", find)
-    curse(dict, "filter_not", filter_not)

--- a/pyfuncol/list.py
+++ b/pyfuncol/list.py
@@ -49,19 +49,6 @@ def filter_not(self: List[A], p: Callable[[A], bool]) -> List[A]:
     return type(self)(x for x in self if not p(x))
 
 
-def filter_not(self: List[A], p: Callable[[A], bool]) -> List[A]:
-    """
-    Selects all elements of this list which do not satisfy a predicate.
-
-    Args:
-        p: The predicate not to satisfy.
-
-    Returns:
-        The filtered list.
-    """
-    return [x for x in self if not p(x)]
-
-
 def flat_map(self: List[A], f: Callable[[A], List[B]]) -> List[B]:
     """
     Builds a new list by applying a function to all elements of this list and using the elements of the resulting collections.

--- a/pyfuncol/list.py
+++ b/pyfuncol/list.py
@@ -1,7 +1,7 @@
 from forbiddenfruit import curse
 from collections import defaultdict
 from typing import Callable, Dict, Optional, TypeVar, List
-from copy import deepcopy
+from copy import deepcopy # needed to preserve subclasses after transformation
 
 A = TypeVar("A")
 B = TypeVar("B")

--- a/pyfuncol/list.py
+++ b/pyfuncol/list.py
@@ -1,6 +1,7 @@
 from forbiddenfruit import curse
 from collections import defaultdict
 from typing import Callable, Dict, Optional, TypeVar, List
+from copy import deepcopy
 
 A = TypeVar("A")
 B = TypeVar("B")
@@ -18,7 +19,11 @@ def map(self: List[A], f: Callable[[A], B]) -> List[B]:
     Returns:
         The new list.
     """
-    return [f(x) for x in self]
+    res = deepcopy(self)
+    res.clear()
+    for x in self:
+        res.append(f(x))
+    return res
 
 
 def filter(self: List[A], p: Callable[[A], bool]) -> List[A]:
@@ -31,7 +36,30 @@ def filter(self: List[A], p: Callable[[A], bool]) -> List[A]:
     Returns:
         The filtered list.
     """
-    return [x for x in self if p(x)]
+    res = deepcopy(self)
+    res.clear()
+    for x in self:
+        if p(x):
+            res.append(x)
+    return res
+
+
+def filter_not(self: List[A], p: Callable[[A], bool]) -> List[A]:
+    """
+    Selects all elements of this list which do not satisfy a predicate.
+
+    Args:
+        p: The predicate to not satisfy.
+
+    Returns:
+        The filtered list.
+    """
+    res = deepcopy(self)
+    res.clear()
+    for x in self:
+        if not p(x):
+            res.append(x)
+    return res
 
 
 def flat_map(self: List[A], f: Callable[[A], List[B]]) -> List[B]:
@@ -44,7 +72,11 @@ def flat_map(self: List[A], f: Callable[[A], List[B]]) -> List[B]:
     Returns:
         The new list.
     """
-    return [y for x in self for y in f(x)]
+    res = deepcopy(self)
+    res.clear()
+    for x in self:
+        res.extend(f(x))
+    return res
 
 
 def flatten(self: List[A]) -> List[B]:
@@ -54,7 +86,11 @@ def flatten(self: List[A]) -> List[B]:
     Returns:
         The flattened list.
     """
-    return [y for x in self for y in x]
+    res = deepcopy(self)
+    res.clear()
+    for x in self:
+        res.extend(x)
+    return res
 
 
 def contains(self: List[A], elem: A) -> bool:
@@ -77,7 +113,11 @@ def distinct(self: List[A]) -> List[A]:
     Returns:
         The list without duplicates.
     """
-    return list(set(self))
+    res = deepcopy(self)
+    res.clear()
+    no_duplicates = list(set(self))
+    res.extend(no_duplicates)
+    return res
 
 
 def foreach(self: List[A], f: Callable[[A], U]) -> None:
@@ -104,7 +144,7 @@ def group_by(self: List[A], f: Callable[[A], K]) -> Dict[K, List[A]]:
     for x in self:
         k = f(x)
         d[k].append(x)
-    return d
+    return dict(d)
 
 
 def is_empty(self: List[A]) -> bool:
@@ -253,7 +293,9 @@ def take(self: List[A], n: int) -> List[A]:
     """
 
     if n < 0:
-        return []
+        l = deepcopy(self)
+        l.clear()
+        return l
     if len(self) <= n:
         return self
 
@@ -276,6 +318,7 @@ def extend_list():
     """
     curse(list, "map", map)
     curse(list, "filter", filter)
+    curse(list, "filter_not", filter_not)
     curse(list, "flat_map", flat_map)
     curse(list, "flatten", flatten)
     curse(list, "contains", contains)

--- a/pyfuncol/list.py
+++ b/pyfuncol/list.py
@@ -19,7 +19,7 @@ def map(self: List[A], f: Callable[[A], B]) -> List[B]:
     Returns:
         The new list.
     """
-    return cast(List[B], type(self)([f(x) for x in self]))
+    return cast(List[B], type(self)(f(x) for x in self))
 
 
 def filter(self: List[A], p: Callable[[A], bool]) -> List[A]:
@@ -32,7 +32,7 @@ def filter(self: List[A], p: Callable[[A], bool]) -> List[A]:
     Returns:
         The filtered list.
     """
-    return type(self)([x for x in self if p(x)])
+    return type(self)(x for x in self if p(x))
 
 
 def filter_not(self: List[A], p: Callable[[A], bool]) -> List[A]:
@@ -45,7 +45,7 @@ def filter_not(self: List[A], p: Callable[[A], bool]) -> List[A]:
     Returns:
         The filtered list.
     """
-    return type(self)([x for x in self if not p(x)])
+    return type(self)(x for x in self if not p(x))
 
 
 def flat_map(self: List[A], f: Callable[[A], List[B]]) -> List[B]:
@@ -58,7 +58,7 @@ def flat_map(self: List[A], f: Callable[[A], List[B]]) -> List[B]:
     Returns:
         The new list.
     """
-    return cast(List[B], type(self)([y for x in self for y in f(x)]))
+    return cast(List[B], type(self)(y for x in self for y in f(x)))
 
 
 def flatten(self: List[A]) -> List[B]:
@@ -68,7 +68,7 @@ def flatten(self: List[A]) -> List[B]:
     Returns:
         The flattened list.
     """
-    return cast(List[B], [y for x in self for y in x])
+    return cast(List[B], type(self)(y for x in self for y in x))
 
 
 def contains(self: List[A], elem: A) -> bool:

--- a/pyfuncol/set.py
+++ b/pyfuncol/set.py
@@ -18,7 +18,7 @@ def map(self: Set[A], f: Callable[[A], B]) -> Set[B]:
     Returns:
         The new set.
     """
-    return {f(x) for x in self}
+    return type(self)({f(x) for x in self})
 
 
 def filter(self: Set[A], p: Callable[[A], bool]) -> Set[A]:
@@ -31,7 +31,20 @@ def filter(self: Set[A], p: Callable[[A], bool]) -> Set[A]:
     Returns:
         The filtered set.
     """
-    return {x for x in self if p(x)}
+    return type(self)({x for x in self if p(x)})
+
+
+def filter_not(self: Set[A], p: Callable[[A], bool]) -> Set[A]:
+    """
+    Selects all elements of this set which do not satisfy a predicate.
+
+    Args:
+        p: The predicate to not satisfy.
+
+    Returns:
+        The filtered set.
+    """
+    return type(self)({x for x in self if not p(x)})
 
 
 def flat_map(self: Set[A], f: Callable[[A], Set[B]]) -> Set[B]:
@@ -44,7 +57,7 @@ def flat_map(self: Set[A], f: Callable[[A], Set[B]]) -> Set[B]:
     Returns:
         The new set.
     """
-    return {y for x in self for y in f(x)}
+    return type(self)({y for x in self for y in f(x)})
 
 
 def contains(self: Set[A], elem: A) -> bool:
@@ -195,10 +208,11 @@ def length(self: Set[A]) -> int:
 
 def extend_set():
     """
-    Extends the set built-in type with methods.
+    Extends the set and frozenset built-in type with methods.
     """
     curse(set, "map", map)
     curse(set, "filter", filter)
+    curse(set, "filter_not", filter_not)
     curse(set, "flat_map", flat_map)
     curse(set, "contains", contains)
     curse(set, "foreach", foreach)
@@ -210,3 +224,18 @@ def extend_set():
     curse(set, "fold_right", fold_right)
     curse(set, "forall", forall)
     curse(set, "length", length)
+
+    curse(frozenset, "map", map)
+    curse(frozenset, "filter", filter)
+    curse(frozenset, "filter_not", filter_not)
+    curse(frozenset, "flat_map", flat_map)
+    curse(frozenset, "contains", contains)
+    curse(frozenset, "foreach", foreach)
+    curse(frozenset, "group_by", group_by)
+    curse(frozenset, "is_empty", is_empty)
+    curse(frozenset, "size", size)
+    curse(frozenset, "find", find)
+    curse(frozenset, "fold_left", fold_left)
+    curse(frozenset, "fold_right", fold_right)
+    curse(frozenset, "forall", forall)
+    curse(frozenset, "length", length)

--- a/pyfuncol/set.py
+++ b/pyfuncol/set.py
@@ -49,19 +49,6 @@ def filter_not(self: Set[A], p: Callable[[A], bool]) -> Set[A]:
     return type(self)(x for x in self if not p(x))
 
 
-def filter_not(self: Set[A], p: Callable[[A], bool]) -> Set[A]:
-    """
-    Selects all elements of this set which do not satisfy a predicate.
-
-    Args:
-        p: The predicate not to satisfy.
-
-    Returns:
-        The filtered set.
-    """
-    return {x for x in self if not p(x)}
-
-
 def flat_map(self: Set[A], f: Callable[[A], Set[B]]) -> Set[B]:
     """
     Builds a new set by applying a function to all elements of this set and using the elements of the resulting collections.

--- a/pyfuncol/set.py
+++ b/pyfuncol/set.py
@@ -32,7 +32,7 @@ def filter(self: Set[A], p: Callable[[A], bool]) -> Set[A]:
     Returns:
         The filtered set.
     """
-    return type(self)({x for x in self if p(x)})
+    return type(self)(x for x in self if p(x))
 
 
 def filter_not(self: Set[A], p: Callable[[A], bool]) -> Set[A]:
@@ -45,7 +45,7 @@ def filter_not(self: Set[A], p: Callable[[A], bool]) -> Set[A]:
     Returns:
         The filtered set.
     """
-    return type(self)({x for x in self if not p(x)})
+    return type(self)(x for x in self if not p(x))
 
 
 def flat_map(self: Set[A], f: Callable[[A], Set[B]]) -> Set[B]:

--- a/pyfuncol/tests/test_dict.py
+++ b/pyfuncol/tests/test_dict.py
@@ -30,10 +30,6 @@ def test_filter_not():
     assert di.filter_not(lambda kv: False) == di
 
 
-def test_filter_not():
-    assert d.filter_not(lambda kv: kv[1] > 1) == {"a": 1}
-
-
 def test_flat_map():
     assert d.flat_map(lambda kv: {kv[0]: kv[1] ** 2}) == {"a": 1, "b": 4, "c": 9}
 

--- a/pyfuncol/tests/test_dict.py
+++ b/pyfuncol/tests/test_dict.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict, defaultdict
+from typing import DefaultDict
 import pyfuncol
 
 d = {"a": 1, "b": 2, "c": 3}
@@ -15,9 +17,34 @@ def test_size():
 def test_filter():
     assert d.filter(lambda kv: kv[1] > 1) == {"b": 2, "c": 3}
 
+    # Test that type is preserved
+    di: OrderedDict[str, int] = OrderedDict(d)
+    assert di.filter(lambda kv: True) == di
+
+    dd: DefaultDict[str, int] = defaultdict(int, d)
+    assert dd.filter(lambda kv: True) == dd
+
+
+def test_filter_not():
+    assert d.filter_not(lambda kv: kv[1] > 1) == {"a": 1}
+
+    # Test that type is preserved
+    di: OrderedDict[str, int] = OrderedDict(d)
+    assert di.filter_not(lambda kv: False) == di
+
+    dd: DefaultDict[str, int] = defaultdict(int, d)
+    assert dd.filter_not(lambda kv: False) == dd
+
 
 def test_flat_map():
     assert d.flat_map(lambda kv: {kv[0]: kv[1] ** 2}) == {"a": 1, "b": 4, "c": 9}
+
+    # Test that type is preserved
+    di: OrderedDict[str, int] = OrderedDict(d)
+    assert di.flat_map(lambda kv: {kv[0]: kv[1]}) == di
+
+    dd: DefaultDict[str, int] = defaultdict(int, d)
+    assert dd.flat_map(lambda kv: {kv[0]: kv[1]}) == dd
 
 
 def test_foreach():
@@ -33,6 +60,13 @@ def test_is_empty():
 
 def test_map():
     assert d.map(lambda kv: (kv[0], kv[1] ** 2)) == {"a": 1, "b": 4, "c": 9}
+
+    # Test that type is preserved
+    di: OrderedDict[str, int] = OrderedDict(d)
+    assert di.map(lambda kv: kv) == di
+
+    dd: DefaultDict[str, int] = defaultdict(int, d)
+    assert dd.map(lambda kv: kv) == dd
 
 
 def test_to_list():
@@ -65,7 +99,3 @@ def test_find():
 
 def test_find_none():
     assert d.find(lambda kv: kv[1] == 5) == None
-
-
-def test_filter_not():
-    assert d.filter_not(lambda kv: kv[1] > 1) == {"a": 1}

--- a/pyfuncol/tests/test_list.py
+++ b/pyfuncol/tests/test_list.py
@@ -31,10 +31,6 @@ def test_filter_not():
     assert lst.filter_not(lambda x: False) == lst
 
 
-def test_filter_not():
-    assert l.filter_not(lambda x: x >= 2) == [1]
-
-
 def test_flat_map():
     assert l.flat_map(lambda x: [x ** 2]) == [1, 4, 9]
 
@@ -238,4 +234,4 @@ def test_pure_filter_not():
     assert l.pure_filter_not(lambda x: x >= 2) == [1]
 
     # Test that type is preserved
-    assert l.pure_filter_not(lambda x: x >= 2) == [1]
+    assert lst.pure_filter_not(lambda x: x >= 2) == [1]

--- a/pyfuncol/tests/test_list.py
+++ b/pyfuncol/tests/test_list.py
@@ -4,20 +4,48 @@ import pytest
 l = [1, 2, 3]
 
 
+class Lst(list):
+    pass
+
+
 def test_map():
     assert l.map(lambda x: x * 2) == [2, 4, 6]
+
+    # Test that type is preserved
+    lst = Lst(l)
+    assert lst.map(lambda x: x) == lst
 
 
 def test_filter():
     assert l.filter(lambda x: x >= 2) == [2, 3]
 
+    # Test that type is preserved
+    lst = Lst(l)
+    assert lst.filter(lambda x: True) == lst
+
+
+def test_filter_not():
+    assert l.filter_not(lambda x: x < 2) == [2, 3]
+
+    # Test that type is preserved
+    lst = Lst(l)
+    assert lst.filter_not(lambda x: False) == lst
+
 
 def test_flat_map():
     assert l.flat_map(lambda x: [x ** 2]) == [1, 4, 9]
 
+    # Test that type is preserved
+    lst = Lst(l)
+    assert lst.flat_map(lambda x: [x]) == lst
+
 
 def test_flatten():
     assert [[1, 2], [3]].flatten() == l
+
+    # Test that type is preserved
+    lst = Lst([[1, 2], [3]])
+    assert lst.flatten() == Lst(l)
 
 
 def test_contains():
@@ -26,6 +54,10 @@ def test_contains():
 
 def test_distinct():
     assert [1, 1, 2, 2, 3].distinct() == l
+
+    # Test that type is preserved
+    lst = Lst([1, 1, 2, 2, 3])
+    assert lst.distinct() == Lst(l)
 
 
 def test_group_by():
@@ -116,15 +148,27 @@ def test_take_neg():
     a = l.take(-1)
     assert a == []
 
+    # Test that type is preserved
+    lst = Lst(l)
+    assert lst.take(-1) == Lst()
+
 
 def test_take_greater_len():
     a = l.take(4)
     assert a == l
 
+    # Test that type is preserved
+    lst = Lst(l)
+    assert lst.take(4) == lst
+
 
 def test_take_smaller_len():
     a = l.take(2)
     assert a == [1, 2]
+
+    # Test that type is preserved
+    lst = Lst(l)
+    assert lst.take(2) == Lst(l.take(2))
 
 
 def test_length():

--- a/pyfuncol/tests/test_set.py
+++ b/pyfuncol/tests/test_set.py
@@ -1,27 +1,40 @@
 import pyfuncol
-import pytest
 
 s = {1, 2, 3}
+st = frozenset(s)
 
 
 def test_map():
     assert s.map(lambda x: x * 2) == {2, 4, 6}
+    assert st.map(lambda x: x * 2) == frozenset({2, 4, 6})
 
 
 def test_filter():
     assert s.filter(lambda x: x >= 2) == {2, 3}
+    assert st.filter(lambda x: x >= 2) == frozenset({2, 3})
+
+
+def test_filter_not():
+    assert s.filter_not(lambda x: x < 2) == {2, 3}
+    assert st.filter_not(lambda x: x < 2) == frozenset({2, 3})
 
 
 def test_flat_map():
-    assert s.flat_map(lambda x: [x ** 2]) == {1, 4, 9}
+    assert s.flat_map(lambda x: {x ** 2}) == {1, 4, 9}
+    assert st.flat_map(lambda x: {x ** 2}) == frozenset({1, 4, 9})
 
 
 def test_contains():
     assert s.contains(2) == True
+    assert st.contains(2) == True
 
 
 def test_group_by():
     assert {"abc", "def", "e"}.group_by(lambda s: len(s)) == {
+        3: {"abc", "def"},
+        1: {"e"},
+    }
+    assert frozenset({"abc", "def", "e"}).group_by(lambda s: len(s)) == {
         3: {"abc", "def"},
         1: {"e"},
     }
@@ -32,14 +45,22 @@ def test_is_empty():
     empty = set()
     assert empty.is_empty() == True
 
+    assert st.is_empty() == False
+    frozen_empty = frozenset()
+    assert frozen_empty.is_empty() == True
+
 
 def test_size():
     assert s.size() == 3
+    assert st.size() == 3
 
 
 def test_find():
     assert s.find(lambda x: x >= 3) == 3
     assert s.find(lambda x: x < 0) == None
+
+    assert st.find(lambda x: x >= 3) == 3
+    assert st.find(lambda x: x < 0) == None
 
 
 def test_foreach():
@@ -47,10 +68,14 @@ def test_foreach():
     s.foreach(lambda x: tester.add(x))
     assert tester == s
 
+    frozen_tester = set()
+    st.foreach(lambda x: frozen_tester.add(x))
+    assert frozen_tester == s
+
 
 def test_fold_left_plus():
-    a = s.fold_left(0, lambda acc, n: acc + n)
-    assert a == 6
+    assert s.fold_left(0, lambda acc, n: acc + n) == 6
+    assert st.fold_left(0, lambda acc, n: acc + n) == 6
 
 
 def test_fold_left_concat():
@@ -59,10 +84,20 @@ def test_fold_left_concat():
         a == "123" or a == "321" or a == "132" or a == "213" or a == "231" or a == "312"
     )
 
+    frozen_a = st.fold_left("", lambda acc, n: acc + str(n))
+    assert (
+        frozen_a == "123"
+        or frozen_a == "321"
+        or frozen_a == "132"
+        or frozen_a == "213"
+        or frozen_a == "231"
+        or frozen_a == "312"
+    )
+
 
 def test_fold_right_plus():
-    a = s.fold_right(0, lambda n, acc: acc + n)
-    assert a == 6
+    assert s.fold_right(0, lambda n, acc: acc + n) == 6
+    assert st.fold_right(0, lambda n, acc: acc + n) == 6
 
 
 def test_fold_right_concat():
@@ -71,21 +106,32 @@ def test_fold_right_concat():
         a == "321" or a == "123" or a == "132" or a == "213" or a == "231" or a == "312"
     )
 
+    frozen_a = st.fold_right("", lambda n, acc: acc + str(n))
+    assert (
+        frozen_a == "321"
+        or frozen_a == "123"
+        or frozen_a == "132"
+        or frozen_a == "213"
+        or frozen_a == "231"
+        or frozen_a == "312"
+    )
+
 
 def test_forall_gt_zero():
-    a = s.forall(lambda n: n > 0)
-    assert a == True
+    assert s.forall(lambda n: n > 0) == True
+    assert st.forall(lambda n: n > 0) == True
 
 
 def test_forall_gt_two():
-    a = s.forall(lambda n: n > 2)
-    assert a == False
+    assert s.forall(lambda n: n > 2) == False
+    assert st.forall(lambda n: n > 2) == False
 
 
 def test_length():
-    a = s.length()
-    assert a == 3
+    assert s.length() == 3
+    assert st.length() == 3
 
 
 def test_length_equal_size():
     assert s.size() == s.length()
+    assert st.size() == st.length()

--- a/pyfuncol/tests/test_set.py
+++ b/pyfuncol/tests/test_set.py
@@ -19,10 +19,6 @@ def test_filter_not():
     assert st.filter_not(lambda x: x < 2) == frozenset({2, 3})
 
 
-def test_filter_not():
-    assert s.filter_not(lambda x: x >= 2) == {1}
-
-
 def test_flat_map():
     assert s.flat_map(lambda x: {x ** 2}) == {1, 4, 9}
     assert st.flat_map(lambda x: {x ** 2}) == frozenset({1, 4, 9})


### PR DESCRIPTION
# Description

In this PR:
- Support for simple `set`, `dict` and `list` subclasses
- Support for `frozenset`
- Add `filter_not` for lists and sets

Fixes #17

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
